### PR TITLE
Feature/request based cookie setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ By default, Ahoy will create visits using Rails controller action callbacks.
 To handle the callbacks yourself, use:
 
 ```ruby
-Ahoy.controller_callbacks = false
+Ahoy.default_controller_callbacks = false
 ```
 
 You could also prevent certain Rails actions from creating visits with:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ When someone visits your website, Ahoy creates a visit with lots of useful infor
 
 Use the `current_visit` method to access it.
 
-Prevent certain Rails actions from creating visits with:
+By default, Ahoy will create visits using Rails controller action callbacks.
+To handle the callbacks yourself, use:
+
+```ruby
+Ahoy.controller_callbacks = false
+```
+
+You could also prevent certain Rails actions from creating visits with:
 
 ```ruby
 skip_before_action :track_ahoy_visit

--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "safely_block", ">= 0.2.1"
   spec.add_dependency "device_detector"
-  spec.add_dependency "request_store"
+  spec.add_dependency "request_store", "~> 1.5.0"
 end

--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "safely_block", ">= 0.2.1"
   spec.add_dependency "device_detector"
+  spec.add_dependency "request_store"
 end

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -60,6 +60,9 @@ module Ahoy
   mattr_accessor :api_only
   self.api_only = false
 
+  mattr_accessor :controller_callbacks
+  self.controller_callbacks = true
+
   mattr_accessor :protect_from_forgery
   self.protect_from_forgery = true
 

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -61,8 +61,8 @@ module Ahoy
   mattr_accessor :api_only
   self.api_only = false
 
-  mattr_accessor :controller_callbacks
-  self.controller_callbacks = true
+  mattr_accessor :default_controller_callbacks
+  self.default_controller_callbacks = true
 
   mattr_accessor :protect_from_forgery
   self.protect_from_forgery = true

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -5,6 +5,7 @@ require "ipaddr"
 require "active_support"
 require "active_support/core_ext"
 require "safely/core"
+require "request_store"
 
 # modules
 require "ahoy/utils"
@@ -27,8 +28,8 @@ module Ahoy
   mattr_accessor :visitor_duration
   self.visitor_duration = 2.years
 
-  mattr_accessor :cookies
-  self.cookies = true
+  mattr_accessor :server_side_cookies
+  self.server_side_cookies = true
 
   # TODO deprecate in favor of cookie_options
   mattr_accessor :cookie_domain
@@ -114,6 +115,23 @@ module Ahoy
 
   def self.instance=(value)
     Thread.current[:ahoy] = value
+  end
+
+  # @return [RequestStore] Request store
+  def self.request_storage
+    RequestStore.store
+  end
+
+  # allow cookies variable based on the current request
+  def self.cookies
+    return server_side_cookies if request_storage[:cookies].nil?
+
+    request_storage[:cookies]
+  end
+
+  # allow cookies variable based on the current request
+  def self.cookies=(value)
+    request_storage[:cookies] = value
   end
 end
 

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -118,20 +118,20 @@ module Ahoy
   end
 
   # @return [RequestStore] Request store
-  def self.request_storage
+  def self.request_store
     RequestStore.store
   end
 
   # allow cookies variable based on the current request
   def self.cookies
-    return server_side_cookies if request_storage[:cookies].nil?
+    return server_side_cookies if request_store[:cookies].nil?
 
-    request_storage[:cookies]
+    request_store[:cookies]
   end
 
   # allow cookies variable based on the current request
   def self.cookies=(value)
-    request_storage[:cookies] = value
+    request_store[:cookies] = value
   end
 end
 

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -6,6 +6,7 @@ module Ahoy
         base.helper_method :ahoy
       end
       base.before_action :set_ahoy_cookies, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
+      base.before_action :delete_ahoy_cookies, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
       base.before_action :track_ahoy_visit, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
       base.around_action :set_ahoy_request_store
     end
@@ -19,13 +20,17 @@ module Ahoy
     end
 
     def set_ahoy_cookies
-      if Ahoy.cookies
-        ahoy.set_visitor_cookie
-        ahoy.set_visit_cookie
-      else
-        # delete cookies if exist
-        ahoy.reset
-      end
+      return unless Ahoy.cookies
+
+      ahoy.set_visitor_cookie
+      ahoy.set_visit_cookie
+    end
+
+    def delete_ahoy_cookies
+      return if Ahoy.cookies
+
+      # delete cookies if exist
+      ahoy.reset
     end
 
     def track_ahoy_visit

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -5,8 +5,8 @@ module Ahoy
         base.helper_method :current_visit
         base.helper_method :ahoy
       end
-      base.before_action :set_ahoy_cookies, unless: -> { Ahoy.api_only }
-      base.before_action :track_ahoy_visit, unless: -> { Ahoy.api_only }
+      base.before_action :set_ahoy_cookies, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
+      base.before_action :track_ahoy_visit, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
       base.around_action :set_ahoy_request_store
     end
 

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -5,9 +5,9 @@ module Ahoy
         base.helper_method :current_visit
         base.helper_method :ahoy
       end
-      base.before_action :set_ahoy_cookies, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
-      base.before_action :delete_ahoy_cookies, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
-      base.before_action :track_ahoy_visit, if: -> { Ahoy.controller_callbacks }, unless: -> { Ahoy.api_only }
+      base.before_action :set_ahoy_cookies, if: -> { Ahoy.default_controller_callbacks }, unless: -> { Ahoy.api_only }
+      base.before_action :delete_ahoy_cookies, if: -> { Ahoy.default_controller_callbacks }, unless: -> { Ahoy.api_only }
+      base.before_action :track_ahoy_visit, if: -> { Ahoy.default_controller_callbacks }, unless: -> { Ahoy.api_only }
       base.around_action :set_ahoy_request_store
     end
 

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -171,6 +171,14 @@ class ControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_controller_callbacks
+    with_options(controller_callbacks: false) do
+      get list_products_url
+      assert_equal 0, Ahoy::Visit.count
+      assert_empty response.cookies
+    end
+  end
+
   def test_cookies_true
     get products_url
     assert_equal ["ahoy_visit", "ahoy_visitor"], response.cookies.keys.sort

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -171,8 +171,8 @@ class ControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_controller_callbacks
-    with_options(controller_callbacks: false) do
+  def test_default_controller_callbacks
+    with_options(default_controller_callbacks: false) do
       get list_products_url
       assert_equal 0, Ahoy::Visit.count
       assert_empty response.cookies


### PR DESCRIPTION
Adds `Ahoy.default_controller_callbacks` configuration that can be used to prevent Ahoy adding actions on all controllers.
Renames `Ahoy.cookies` configuration to `Ahoy.server_side_cookies`.
Adds an `Ahoy.cookies` value (defaults to `Ahoy.server_side_cookies` value) at a per-Rack-request level (adds dependency `request_store`)
Splits the `set_ahoy_cookies` action into a `set_` and a `delete_` action.
Adds tests for above features.

