### PR TITLE
Feature/automatic tracking and tracker booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,22 @@ When someone visits your website, Ahoy creates a visit with lots of useful infor
 
 Use the `current_visit` method to access it.
 
-By default, Ahoy will create visits using Rails controller action callbacks.
-To handle the callbacks yourself, use:
+By default, Ahoy will create visits and set cookies.
+To handle these yourself, use:
 
 ```ruby
-Ahoy.default_controller_callbacks = false
+Ahoy.automatic_tracking = false
 ```
 
-You could also prevent certain Rails actions from creating visits with:
+and then in the controllers you want to track, use:
+
+```ruby
+before_action :set_ahoy_cookies
+before_action :delete_ahoy_cookies
+before_action :track_ahoy_visit
+```
+
+You could also leave automatic tracking on and prevent certain Rails actions from creating visits with:
 
 ```ruby
 skip_before_action :track_ahoy_visit

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -61,8 +61,8 @@ module Ahoy
   mattr_accessor :api_only
   self.api_only = false
 
-  mattr_accessor :default_controller_callbacks
-  self.default_controller_callbacks = true
+  mattr_accessor :automatic_tracking
+  self.automatic_tracking = true
 
   mattr_accessor :protect_from_forgery
   self.protect_from_forgery = true

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -5,9 +5,9 @@ module Ahoy
         base.helper_method :current_visit
         base.helper_method :ahoy
       end
-      base.before_action :set_ahoy_cookies, if: -> { Ahoy.default_controller_callbacks }, unless: -> { Ahoy.api_only }
-      base.before_action :delete_ahoy_cookies, if: -> { Ahoy.default_controller_callbacks }, unless: -> { Ahoy.api_only }
-      base.before_action :track_ahoy_visit, if: -> { Ahoy.default_controller_callbacks }, unless: -> { Ahoy.api_only }
+      base.before_action :set_ahoy_cookies, if: -> { Ahoy.automatic_tracking }, unless: -> { Ahoy.api_only }
+      base.before_action :delete_ahoy_cookies, if: -> { Ahoy.automatic_tracking }, unless: -> { Ahoy.api_only }
+      base.before_action :track_ahoy_visit, if: -> { Ahoy.automatic_tracking }, unless: -> { Ahoy.api_only }
       base.around_action :set_ahoy_request_store
     end
 

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -145,6 +145,14 @@ module Ahoy
       delete_cookie("ahoy_track")
     end
 
+    def visitor_using_anonymity_set?
+      visitor_anonymity_set == visitor_token_helper
+    end
+
+    def visit_using_anonymity_set?
+      visit_anonymity_set == visit_token_helper
+    end
+
     protected
 
     def api?

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -171,8 +171,8 @@ class ControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_default_controller_callbacks
-    with_options(default_controller_callbacks: false) do
+  def test_automatic_tracking
+    with_options(automatic_tracking: false) do
       get list_products_url
       assert_equal 0, Ahoy::Visit.count
       assert_empty response.cookies

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -11,12 +11,32 @@ class TrackerTest < Minitest::Test
     assert_nil event.user_id
   end
 
+  def test_cookies
+    request = ActionDispatch::TestRequest.create
+
+    with_options(cookies: true) do
+      ahoy = Ahoy::Tracker.new(request: request)
+      ahoy.track("Some event", some_prop: true)
+
+      refute ahoy.visitor_using_anonymity_set?
+      refute ahoy.visit_using_anonymity_set?
+    end
+
+    event = Ahoy::Event.last
+    assert_equal "Some event", event.name
+    assert_equal({"some_prop" => true}, event.properties)
+    assert_nil event.user_id
+  end
+
   def test_no_cookies
     request = ActionDispatch::TestRequest.create
 
     with_options(cookies: false) do
       ahoy = Ahoy::Tracker.new(request: request)
       ahoy.track("Some event", some_prop: true)
+
+      assert ahoy.visitor_using_anonymity_set?
+      assert ahoy.visit_using_anonymity_set?
     end
 
     event = Ahoy::Event.last


### PR DESCRIPTION
Changes controller actions to use the `Ahoy.automatic_tracking` configuration boolean.
Updates documentation.
Adds `visit_using_anonymity_set?` and `visitor_using_anonymity_set?` booleans to the `Ahoy::Tracker`.